### PR TITLE
Cleaned up RCS_Rate_Sheet.csv to fix sorting

### DIFF
--- a/docs/RCP_Rate_Sheet.csv
+++ b/docs/RCP_Rate_Sheet.csv
@@ -1,45 +1,45 @@
-﻿Launcher Type,Configuration Name,Cores,Memory,GPU?,Hourly Cost
-JupyterLab,Medium-general-purpose-instance,2 cores,4 GB,,$0.04
-JupyterLab,Large-general-purpose-instance,2 cores,8 GB,,$0.09
-JupyterLab,Medium-compute-optimized-instance,1 core,2 GB,,
-JupyterLab,Large-compute-optimized-instance,2 cores,4 GB,,$0.10
-JupyterLab,Accelerated-instance-for-ML,4 cores,16 GB,TRUE,
-Rstudio,Medium-general-purpose-instance,2 cores,4 GB,,
-Rstudio,Large-general-purpose-instance,2 cores,8 GB,,$0.09
-Rstudio,Medium-compute-optimized-instance,1 core,2 GB,,
-Rstudio,Large-compute-optimized-instance,2 cores,4 GB,,$0.10
-Rstudio,Accelerated-instance-for-ML,4 cores,16 GB,TRUE,$0.53
-Rstudio,Extra-large-general-purpose-instance,4 cores,16 GB,,$0.17
-Rstudio,Compute-memory-balanced-large-instance,4 cores,16 GB,,$0.19
-Rstudio,Memory-optimized-large-instance,2 cores,16 GB,,$0.13
-Rstudio,Memory-optimized-extra-large-instance,4 cores,32 GB,,$0.25
-Rstudio,Memory-optimized-double-extra-large-instance,8 cores,64 GB,,$0.50
-Spyder,Large-general-purpose-instance,4 cores,16 GB,,$0.17
-Spyder,Extra-large-general-purpose-instance,8 cores,32 GB,,$0.33
-Spyder,Large-compute-optimized-instance,8 cores,16 GB,,$0.41
-Spyder,Extra-large-compute-optimized-instance,16 cores,32 GB,,$0.82
-Spyder,Extra-large-accelerated-instance,4 cores,16 GB,TRUE,
-Stata,Medium-general-purpose-instance,2 cores,4 GB,,$0.04
-Stata,Large-general-purpose-Instance,2 cores,8 GB,,
-Stata,Large-general-purpose-instance,4 cores,16 GB,,$0.17
-Stata,Extra-double-large-general-purpose-instance,8 cores,32 GB,,$0.33
-Stata,Large-compute-optimized-instance,8 cores,16 GB,,$0.41
-Stata,Extra-large-compute-optimized-instance,16 cores,32 GB,,$0.82
-Stata,Extra-large-general-purpose-instance,4 cores,16 GB,TRUE,$1.01
-VSCode,Medium-general-purpose-instance,2 cores,4 GB,,
-VSCode,Large-general-purpose-instance,2 cores,8 GB,,$0.09
-VSCode,Medium-compute-optimized-instance,1 core,2 GB,,
-VSCode,Large-compute-optimized-instance,2 cores,4 GB,,$0.10
-VSCode,Accelerated-instance-for-ML,4 cores,16 GB,TRUE,$0.53
-VSCode,Accelerated-g4extralarge-instance-for-ML,48 cores,192 GB,TRUE,$3.91
-VSCode,Accelerated-g6extralarge-instance-for-ML,48 cores,192 GB,TRUE,$4.60
-VSCode,Extra-large-general-purpose-instance,4 cores,16 GB,,$0.17
-VSCode,Compute-memory-balanced-large-instance,4 cores,16 GB,,$0.19
-VSCode,Memory-optimized-large-instance,2 cores,16 GB,,$0.13
-VSCode,Memory-optimized-extra-large-instance,4 cores,32 GB,,$0.25
-VSCode,Memory-optimized-double-extra-large-instance,8 cores,64 GB,,$0.50
-sagemakerCanvas,SageMaker-Canvas-Default,,,,
-sagemakerNotebook,Medium-instance-SageMaker,2 cores,4 GB,,
-sagemakerNotebook,Large-instance-SageMaker,2 cores,8 GB,,$0.08
-sagemakerNotebook,Extra-large-instance-SageMaker,4 cores,32 GB,,$0.17
-sagemakerNotebook,ml.g4dn.xlarge,1 core,4 GB,TRUE,$0.74
+﻿Launcher Type,Configuration Name,Cores,Memory (GB),GPU?,Hourly Cost
+JupyterLab,Medium-general-purpose-instance,2,4,-,$0.04
+JupyterLab,Large-general-purpose-instance,2,8,-,$0.09
+JupyterLab,Medium-compute-optimized-instance,1 core,2,-,TBA
+JupyterLab,Large-compute-optimized-instance,2,4,-,$0.10
+JupyterLab,Accelerated-instance-for-ML,4,16,GPU,TBA
+Rstudio,Medium-general-purpose-instance,2,4,-,TBA
+Rstudio,Large-general-purpose-instance,2,8,-,$0.09
+Rstudio,Medium-compute-optimized-instance,1 core,2,-,TBA
+Rstudio,Large-compute-optimized-instance,2,4,-,$0.10
+Rstudio,Accelerated-instance-for-ML,4,16,GPU,$0.53
+Rstudio,Extra-large-general-purpose-instance,4,16,-,$0.17
+Rstudio,Compute-memory-balanced-large-instance,4,16,-,$0.19
+Rstudio,Memory-optimized-large-instance,2,16,-,$0.13
+Rstudio,Memory-optimized-extra-large-instance,4,32,-,$0.25
+Rstudio,Memory-optimized-double-extra-large-instance,8,64,-,$0.50
+Spyder,Large-general-purpose-instance,4,16,-,$0.17
+Spyder,Extra-large-general-purpose-instance,8,32,-,$0.33
+Spyder,Large-compute-optimized-instance,8,16,-,$0.41
+Spyder,Extra-large-compute-optimized-instance,16,32,-,$0.82
+Spyder,Extra-large-accelerated-instance,4,16,GPU,TBA
+Stata,Medium-general-purpose-instance,2,4,-,$0.04
+Stata,Large-general-purpose-Instance,2,8,-,TBA
+Stata,Large-general-purpose-instance,4,16,-,$0.17
+Stata,Extra-double-large-general-purpose-instance,8,32,-,$0.33
+Stata,Large-compute-optimized-instance,8,16,-,$0.41
+Stata,Extra-large-compute-optimized-instance,16,32,-,$0.82
+Stata,Extra-large-general-purpose-instance,4,16,GPU,$1.01
+VSCode,Medium-general-purpose-instance,2,4,-,TBA
+VSCode,Large-general-purpose-instance,2,8,-,$0.09
+VSCode,Medium-compute-optimized-instance,1 core,2,-,TBA
+VSCode,Large-compute-optimized-instance,2,4,-,$0.10
+VSCode,Accelerated-instance-for-ML,4,16,GPU,$0.53
+VSCode,Accelerated-g4extralarge-instance-for-ML,48,192,GPU,$3.91
+VSCode,Accelerated-g6extralarge-instance-for-ML,48,192,GPU,$4.60
+VSCode,Extra-large-general-purpose-instance,4,16,-,$0.17
+VSCode,Compute-memory-balanced-large-instance,4,16,-,$0.19
+VSCode,Memory-optimized-large-instance,2,16,-,$0.13
+VSCode,Memory-optimized-extra-large-instance,4,32,-,$0.25
+VSCode,Memory-optimized-double-extra-large-instance,8,64,-,$0.50
+sagemakerCanvas,SageMaker-Canvas-Default,-,-,-,TBA
+sagemakerNotebook,Medium-instance-SageMaker,2,4,-,TBA
+sagemakerNotebook,Large-instance-SageMaker,2,8,-,$0.08
+sagemakerNotebook,Extra-large-instance-SageMaker,4,32,-,$0.17
+sagemakerNotebook,ml.g4dn.xlarge,1 core,4,GPU,$0.74

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -24,54 +24,6 @@ Costs for the RCP are dictated by Amazon Web Services (AWS), which sets rates ba
 
 Active projects incur project storage and launcher costs. The cost of running launcher sessions will vary based on the configuration selected; see the below table for hourly rates of the different launcher configurations. A stopped launcher will incur minor costs (due to storage). There is no cost for unlaunched launchers. You can associate as many launchers with a project as you’d like and will only incur costs when a session is created. 
 
-| Launcher Type | Configuration Name               | Cores   | Memory | GPU? | Hourly Cost |
-| ------------- | ------------------               | -----   | ------ | ---- | ----------- |
-| JupyterLab    |	Medium-general-purpose-instance	 | 2 cores | 4 GB   |	     | $0.04 |
-| JupyterLab	  | Large-general-purpose-instance	 | 2 cores | 8 GB   |      | $0.09 |
-| JupyterLab	  | Large-compute-optimized-instance | 2 cores | 4 GB   |		   | $0.10 |
-| Rstudio	      | Large-general-purpose-instance	 | 2 cores | 8 GB   |      | $0.09 |
-| Rstudio	      | Large-compute-optimized-instance | 2 cores | 4 GB   |      |	$0.10 |
-| Rstudio | Large-general-purpose-instance | 2 cores | 8 GB |  | $0.09 |
-| Rstudio | Medium-compute-optimized-instance | 1 core | 2 GB |  |  |
-| Rstudio | Large-compute-optimized-instance | 2 cores | 4 GB |  | $0.10 |
-| Rstudio | Accelerated-instance-for-ML | 4 cores | 16 GB | GPU | $0.53 |
-| Rstudio | Extra-large-general-purpose-instance | 4 cores | 16 GB |  | $0.17 |
-| Rstudio | Compute-memory-balanced-large-instance | 4 cores | 16 GB |  | $0.19 |
-| Rstudio | Memory-optimized-large-instance | 2 cores | 16 GB |  | $0.13 |
-| Rstudio | Memory-optimized-extra-large-instance | 4 cores | 32 GB |  | $0.25 |
-| Rstudio | Memory-optimized-double-extra-large-instance | 8 cores | 64 GB |  | $0.50 |
-| Spyder | Large-general-purpose-instance | 4 cores | 16 GB |  | $0.17 |
-| Spyder | Extra-large-general-purpose-instance | 8 cores | 32 GB |  | $0.33 |
-| Spyder | Large-compute-optimized-instance | 8 cores | 16 GB |  | $0.41 |
-| Spyder | Extra-large-compute-optimized-instance | 16 cores | 32 GB |  | $0.82 |
-| Spyder | Extra-large-accelerated-instance | 4 cores | 16 GB | GPU |  |
-| Stata | Medium-general-purpose-instance | 2 cores | 4 GB |  | $0.04 |
-| Stata | Large-general-purpose-Instance | 2 cores | 8 GB |  |  |
-| Stata | Large-general-purpose-instance | 4 cores | 16 GB |  | $0.17 |
-| Stata | Extra-double-large-general-purpose-instance | 8 cores | 32 GB |  | $0.33 |
-| Stata | Large-compute-optimized-instance | 8 cores | 16 GB |  | $0.41 |
-| Stata | Extra-large-compute-optimized-instance | 16 cores | 32 GB |  | $0.82 |
-| Stata | Extra-large-general-purpose-instance | 4 cores | 16 GB | GPU | $1.01 |
-| VSCode | Medium-general-purpose-instance | 2 cores | 4 GB |  |  |
-| VSCode | Large-general-purpose-instance | 2 cores | 8 GB |  | $0.09 |
-| VSCode | Medium-compute-optimized-instance | 1 core | 2 GB |  |  |
-| VSCode | Large-compute-optimized-instance | 2 cores | 4 GB |  | $0.10 |
-| VSCode | Accelerated-instance-for-ML | 4 cores | 16 GB | GPU | $0.53 |
-| VSCode | Accelerated-g4extralarge-instance-for-ML | 48 cores | 192 GB | GPU | $3.91 |
-| VSCode | Accelerated-g6extralarge-instance-for-ML | 48 cores | 192 GB | GPU | $4.60 |
-| VSCode | Extra-large-general-purpose-instance | 4 cores | 16 GB |  | $0.17 |
-| VSCode | Compute-memory-balanced-large-instance | 4 cores | 16 GB |  | $0.19 |
-| VSCode | Memory-optimized-large-instance | 2 cores | 16 GB |  | $0.13 |
-| VSCode | Memory-optimized-extra-large-instance | 4 cores | 32 GB |  | $0.25 |
-| VSCode | Memory-optimized-double-extra-large-instance | 8 cores | 64 GB |  | $0.50 |
-| sagemakerCanvas | SageMaker-Canvas-Default |  |  |  |  |
-| sagemakerNotebook | Medium-instance-SageMaker | 2 cores | 4 GB |  |  |
-| sagemakerNotebook | Large-instance-SageMaker | 2 cores | 8 GB |  | $0.08 |
-| sagemakerNotebook | Extra-large-instance-SageMaker | 4 cores | 32 GB |  | $0.17 |
-| sagemakerNotebook | ml.g4dn.xlarge | 1 core | 4 GB | GPU | $0.74 |
-
-TEST:
-
 {{ read_csv('RCP_Rate_Sheet.csv') }}
 
 ### Dormant and Archived Projects 


### PR DESCRIPTION
Removed "cores" and "GB" from CPU and memory cells so that tablesort will recognize the sort method on numbers, not strings

Also removed initial markdown table from billing.md; now the only table on the page is the one where table reader pulls from RCP_Rate_Sheet.csv.